### PR TITLE
#8 docs/fuzzing-component-adr "Add ADR for standalone fuzzing component"

### DIFF
--- a/assets/ArchitecturalDecisionRecords/adr-independent-fuzzing-component.md
+++ b/assets/ArchitecturalDecisionRecords/adr-independent-fuzzing-component.md
@@ -1,0 +1,34 @@
+# Architectural Decision Record - Standalone Fuzzing Component
+
+- [ ] ADR under construction 🚧
+- [ ] In Review ⏳
+- [x] Accepted ✅
+- [ ] Rejected ❌
+
+# Context and Problem Statement
+
+"We want to run the fuzzer async and also concurrently from the patch-generation and the patch-evaluation system components, because each fuzzer run for each potentially vulnerable program can be a long running job"
+
+## Options Considered
+- A: Extract python code as is from autopatch-llm 
+- B: implement fuzzing service in golang
+- C: implement fuzzing service in C
+
+## Decision Outcome
+
+Option A Extract and refactor python code from main component into standalone python component and container
+
+## Consequences
+
+### Option A
+- positives - python  - python code already exists and is tested as basically functional- negatives - python  - low support for concurrency
+
+### Option B
+- positives - golang
+  - high support for concurrency
+- negatives - golang  - mental overhead of using different programming language   - requires additional testing
+
+### Option C
+- positives - C
+  - performant  - familiar to Professor Wang
+- negatives - C  - mental overhead of using different programming language   - low level APIs negatively affect development velocity

--- a/assets/ArchitecturalDecisionRecords/template-adr.md
+++ b/assets/ArchitecturalDecisionRecords/template-adr.md
@@ -1,0 +1,28 @@
+# {short title, representative of solved problem and found solution}
+
+- [ ] ADR under construction 🚧
+- [ ] In Review ⏳
+- [x] Accepted ✅
+- [ ] Rejected ❌
+
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story. You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because {justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->

--- a/assets/TechnicalSpikes/template-technical-spike.md
+++ b/assets/TechnicalSpikes/template-technical-spike.md
@@ -1,0 +1,29 @@
+# Template: Technical Spike
+
+## Spike: [Spike Name]
+Conducted by: {Names and at least one email address for follow-up questions}
+Backlog Work Item: {Link to the work item to provide more context}
+Sprint: {Which sprint did the study take place. Include sprint start date}
+
+## Goal
+Describe what question(s) the spike intends to answer and why.
+
+## Method
+Describe how the team will uncover the answer to the question(s) the spike intends to answer. For example:
+
+Build prototype to test.
+Research existing documents and samples.
+Discuss with subject matter experts.
+
+## Evidence
+Document the evidence collected that informed the conclusions below. Examples may include:
+
+Recorded or live demos of a prototype providing the desired capabilities
+Metrics collected while testing the prototype
+Documentation that indicates the solution can provided the desired capabilities
+
+## Conclusions
+What was the answer to the question(s) outlined at the start of the spike? Capture what was learned that will inform future work.
+
+## Next Steps
+What work is expected as an outcome of the learning within this spike. Was there work that was blocked or dependent on the learning within this spike?


### PR DESCRIPTION
# Add ADR for standalone fuzzing component

## Description
This PR adds
- [an Architectural Decision Record (ADR) for extracting the functionality of the fuzzing component from v1 into a standalone container](https://github.com/sysec-uic/AutoPatch-LLM/blob/d3cf4e1bb023e7d68a6e1cbbbc37562312be137e/assets/ArchitecturalDecisionRecords/adr-independent-fuzzing-component.md)
- [A template for ADRs](https://github.com/sysec-uic/AutoPatch-LLM/blob/d3cf4e1bb023e7d68a6e1cbbbc37562312be137e/assets/ArchitecturalDecisionRecords/template-adr.md)
- [A template for Technical Spikes (AKA Research Spikes)](https://github.com/sysec-uic/AutoPatch-LLM/blob/d3cf4e1bb023e7d68a6e1cbbbc37562312be137e/assets/TechnicalSpikes/template-technical-spike.md)

## Code Quality Checklist
<!-- Please check off the following items: -->
- [x] My code follows the project's coding standards.
- [N/A] I have performed a self-review of my own code.
- [N/A] I have commented my code, especially in hard-to-understand areas.
- [N/A] I have added tests that prove my fix is effective or that my feature works.
- [N/A] New and existing tests pass locally with my changes.
- [x] I have checked for any linting or style issues.

## Related Issues

- Resolves #8 

## Screenshots
N/A

## Testing
N/A
