### PR TITLE
Enable flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 170
+extend-ignore = E203

--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 170
+extend-ignore = E203

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -34,6 +34,10 @@ jobs:
           sparse-checkout: |
             .github
             src
+      - name: Display stats for flake8 file
+        env:
+          PYTHON_FLAKE8_CONFIG_FILE: ${{ github.workspace }}/.flake8
+        run: stat ${{ env.PYTHON_FLAKE8_CONFIG_FILE }}
       - name: Super-linter
         uses: super-linter/super-linter@85f7611e0f7b53c8573cca84aa0ed4344f6f6a4d # v7.2.1 # x-release-please-version
         env:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -43,7 +43,6 @@ jobs:
         env:
           # To report GitHub Actions status checks only, allow devs to fix their own PRs
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PYTHON_FLAKE8_CONFIG_FILE: ${{ github.workspace }}/.flake8
           FIX_MARKDOWN: false
           FIX_MARKDOWN_PRETTIER: false
           FIX_YAML_PRETTIER: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,10 +26,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FIX_MARKDOWN: false
-          FIX_YAML_PRETTIER: false
-          FIX_PYTHON_BLACK: false
-          FIX_PYTHON_ISORT: false
         with:
           # super-linter needs the full git history to get the
           # list of files that changed across commits
@@ -57,7 +53,6 @@ jobs:
           VALIDATE_PYTHON_PYINK: false
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_PYTHON_RUFF: false
-          VALIDATE_PYTHON_FLAKE8: false
           VALIDATE_CLANG_FORMAT: false
           VALIDATE_CPP: false
           VALIDATE_JAVASCRIPT_STANDARD: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -39,6 +39,7 @@ jobs:
         env:
           # To report GitHub Actions status checks only, allow devs to fix their own PRs
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHON_FLAKE8_CONFIG_FILE: ${{ github.workspace }}/.flake8
           FIX_MARKDOWN: false
           FIX_MARKDOWN_PRETTIER: false
           FIX_YAML_PRETTIER: false

--- a/src/main.py
+++ b/src/main.py
@@ -176,7 +176,7 @@ def extract_crashes(code_name, inputFromFile):
                 # Convert the crash to utf-8 to solve issues in opening the file
                 command = f"iconv -f ISO-8859-1 -t UTF-8 '{file_path}' > '{file_path}'"
                 try:
-                    result = subprocess.run(
+                    subprocess.run(
                         [command],
                         stderr=subprocess.PIPE,
                         stdout=subprocess.PIPE,
@@ -411,7 +411,7 @@ def main():
         while continuePatching:
             # save the patch as a file
             code_path = f"{code_name}_{patch_num}{code_path[-2:]}"
-            patch = parse_reply(gpt_response, code_path)
+            parse_reply(gpt_response, code_path)
             # test the patch with ASan and fuzzer
             patch_result, gpt_response = test_patch(
                 client, original_code, code_path, inputFromFile, crashes


### PR DESCRIPTION
# Enable flake8


## Description

Enable flake8 in the CI linting step, add flake8 config file which will potentially migrate into pyprojet toml later, remove unused vars reported by flake8, temporarily set allowable line length to 170 which will go to 120 at a future revision

aligns the project with the documented coding standards in draft at: https://github.com/sysec-uic/AutoPatch-LLM/pull/32/files?short_path=eca12c0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055


## Code Quality Checklist
<!-- Please check off the following items: -->
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my own code.
- [N/A] I have commented my code, especially in hard-to-understand areas.
- [N/A] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] I have checked for any linting or style issues.

## Related Issues
<!-- Add any related work items -->

## Screenshots
This change clears `flake8` warnings
<img width="552" alt="image" src="https://github.com/user-attachments/assets/3e002146-e77f-4274-8040-c15cf9a491b0" />

![image](https://github.com/user-attachments/assets/6b3d4c93-fac8-4087-8128-449ce0d9d258)


automated tests run:
<img width="776" alt="image" src="https://github.com/user-attachments/assets/10b14a90-e499-4bbf-b278-4554b20defff" />


## Testing
- ran `flake8` at the root
- this PR should have flake8 run in CI as well

