### PR TITLE
feature(releases): Add first pre-release GHA for tracking latest tag to main branch

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -62,7 +62,8 @@
 				"mechatroner.rainbow-csv",
 				"bierner.markdown-mermaid",
 				"bpruitt-goddard.mermaid-markdown-syntax-highlighting",
-				"MS-vsliveshare.vsliveshare"
+				"MS-vsliveshare.vsliveshare",
+				"GitHub.vscode-github-actions"
 			],
 			"settings": {
 				"[python]": {

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,6 +3,10 @@ name: "pre-release"
 run-name: "Pre Release by @${{ github.actor }}"
 
 on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "main"
   push:
     branches:
       - "main"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -65,5 +65,5 @@ jobs:
           prerelease: true
           title: "Development Build"
           files: |
-            *.whl
-            autopatchdatatypes-*.tar.gz
+            **/*.whl
+            **/autopatchdatatypes-*.tar.gz

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -43,7 +43,10 @@ jobs:
           python -m pip install --upgrade pip
       - name: Install build module
         run: |
-          pip install build
+          pip install build==1.2.2.post1
+      - name: Install test module
+        run: |
+          pip install pytest==8.3.4
       - name: Build AutoPatch.Datatypes Package
         run: task autopatchdatatypes:build
       - name: Install AutoPatch.Datatypes Package

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           egress-policy: audit
       - name: arduino/setup-task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 v2.0.0
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -47,7 +47,8 @@ jobs:
       - name: "Build & test"
         run: |
           task test
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - name: Automatic Releases
+        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,58 @@
+---
+name: "pre-release"
+run-name: "Pre Release by @${{ github.actor }}"
+
+on:
+  push:
+    branches:
+      - "main"
+
+env:
+  PYTHON_VERSION: "3.12.3"
+
+jobs:
+  pre-release:
+    name: "Pre Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Harden-Runner
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
+      - name: arduino/setup-task
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 v2.0.0
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: |
+            .github
+            src
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Upgrade pip 
+        run: |
+          python -m pip install --upgrade pip
+      - name: Install build module
+        run: |
+          pip install build
+      - name: Build AutoPatch.Datatypes Package
+        working-directory: src/autopatchdatatypes
+        run: task auto_patch_datatypes:build # run: python -m build
+      - name: Install AutoPatch.Datatypes Package
+        working-directory: src/autopatchdatatypes
+        run: task auto_patch_datatypes:install
+      - name: "Build & test"
+        run: |
+          task test
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            *.whl
+            autopatchdatatypes-*.tar.gz

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -33,6 +33,7 @@ jobs:
           sparse-checkout: |
             .github
             src
+            Taskfile.yml
       - name: Set up Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v4
         with:
@@ -44,10 +45,8 @@ jobs:
         run: |
           pip install build
       - name: Build AutoPatch.Datatypes Package
-        working-directory: src/autopatchdatatypes
         run: task autopatchdatatypes:build
       - name: Install AutoPatch.Datatypes Package
-        working-directory: src/autopatchdatatypes
         run: task autopatchdatatypes:install
       - name: "Build & test"
         run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -12,6 +12,9 @@ on:
       - "main"
       - "feature/automatic-pre-release-latest-dev-build"
 
+permissions:
+  contents: write
+
 env:
   PYTHON_VERSION: "3.12.3"
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - "main"
+      - "feature/automatic-pre-release-latest-dev-buildfeature/automatic-pre-release-latest-dev-build"
 
 env:
   PYTHON_VERSION: "3.12.3"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - "main"
-      - "feature/automatic-pre-release-latest-dev-buildfeature/automatic-pre-release-latest-dev-build"
+      - "feature/automatic-pre-release-latest-dev-build"
 
 env:
   PYTHON_VERSION: "3.12.3"
@@ -45,10 +45,10 @@ jobs:
           pip install build
       - name: Build AutoPatch.Datatypes Package
         working-directory: src/autopatchdatatypes
-        run: task auto_patch_datatypes:build # run: python -m build
+        run: task autopatchdatatypes:build
       - name: Install AutoPatch.Datatypes Package
         working-directory: src/autopatchdatatypes
-        run: task auto_patch_datatypes:install
+        run: task autopatchdatatypes:install
       - name: "Build & test"
         run: |
           task test

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,14 +3,9 @@ name: "pre-release"
 run-name: "Pre Release by @${{ github.actor }}"
 
 on:
-  workflow_dispatch:
-  pull_request:
-    branches:
-      - "main"
   push:
     branches:
       - "main"
-      - "feature/automatic-pre-release-latest-dev-build"
 
 permissions:
   contents: write

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,22 +1,25 @@
 version: '3'
 
 includes:
- autopatch:
-    taskfile: ./src/Taskfile.yml
-    dir: ./src
- fuzzing-service:
-    taskfile: ./src/fuzzing-service/Taskfile.yml
-    dir: ./src/fuzzing-service
- llm-dispatch:
-    taskfile: ./src/llm-dispatch/Taskfile.yml
-    dir: ./src/llm-dispatch
+   autopatch:
+      taskfile: ./src/Taskfile.yml
+      dir: ./src
+   fuzzing-service:
+      taskfile: ./src/fuzzing-service/Taskfile.yml
+      dir: ./src/fuzzing-service
+   llm-dispatch:
+      taskfile: ./src/llm-dispatch/Taskfile.yml
+      dir: ./src/llm-dispatch
+   autopatchdatatypes:
+      taskfile: ./src/autopatchdatatypes/Taskfile.yml
+      dir: ./src/autopatchdatatypes
 
 tasks:
    test:
       desc: Run tests
       cmds:
          - "echo 'Running tests...'"
-         - "echo Not Yet Implemented"
+         - task fuzzing-service:test
          # - task: autopatch:test
    lint:
       desc: Run linter

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,8 +19,7 @@ tasks:
       desc: Run tests
       cmds:
          - "echo 'Running tests...'"
-         - task fuzzing-service:test
-         # - task: autopatch:test
+         - pytest
    lint:
       desc: Run linter
       cmds:

--- a/src/autopatchdatatypes/Taskfile.yml
+++ b/src/autopatchdatatypes/Taskfile.yml
@@ -14,4 +14,9 @@ tasks:
     cmds:
       - echo "Installing AutoPatch datatypes"
       - pip install {{.CLI_ARGS}} $ARGS ./dist/*.whl
+  test:
+    desc: Run AutoPatch Datatypes automated tests
+    cmds:
+      - echo "Running AutoPatch Datatypes automated tests"
+      - pytest
     

--- a/src/autopatchdatatypes/Taskfile.yml
+++ b/src/autopatchdatatypes/Taskfile.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+env:
+  ARGS: --break-system-packages # Use this If you are installing packages using the Taskfile Extension for VSCode UI and devcontainer
+
+tasks:
+  build:
+    desc: Build AutoPatch datatypes
+    cmds:
+      - echo "Building AutoPatch datatypes"
+      - python -m build
+  install:
+    desc: Install AutoPatch datatypes
+    cmds:
+      - echo "Installing AutoPatch datatypes"
+      - pip install {{.CLI_ARGS}} $ARGS ./dist/*.whl
+    


### PR DESCRIPTION
#  Add first pre-release GHA for tracking latest tag to main branch

## Description
This PR adds:
  - github action for **pre-release** which will automatically create and track a 'latest' tag on the most recent merge to the `main` branch after building any packages and running automated tests
  - SEE THE RELEASE HERE: https://github.com/sysec-uic/AutoPatch-LLM/releases/tag/latest
  - Github Action extension to devcontainer
  - Taskfile for autopatchdatatypes and hook into the root Taskfile to build and install the module 

## Code Quality Checklist
<!-- Please check off the following items: -->
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, especially in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [ ] I have checked for any linting or style issues.

## Related Issues

## Screenshots
<img width="1339" alt="image" src="https://github.com/user-attachments/assets/de509b93-953c-46a4-8d86-ad7c4a501e71" />

<img width="595" alt="image" src="https://github.com/user-attachments/assets/7964db85-c995-4bd8-955d-e1732ea46358" />

## Testing
automated tests pass 
