### PR TITLE
bugfix(devcontainer): remove env file from devontainer initial start up so devs have to opt in to use it instead of by default

### DIFF
--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -1,3 +1,7 @@
+# Optional.  To use, add:
+#     "--env-file", ".devcontainer/devcontainer.env"
+# to your "runArgs" array in devcontainer.json
+
 FUZZ_SVC_CONFIG=/workspace/AutoPatch-LLM/src/fuzzing-service/dev-config.json
 OPEN_API_KEY='CHANGE_ME'
 LLAMA_API_KEY='CHANGE_ME'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -82,8 +82,6 @@
 	"initializeCommand": ["python3", "assets/create-docker-network.py"],
 	"runArgs": [
 		"--network", "autopatch-llm_autopatch-docker-network"
-		// uncomment to add your own env vars
-		// "--env-file", ".devcontainer/devcontainer.env"
 	],
 	"postCreateCommand": "task autopatch:install-devtools",
 	"postStartCommand": "fastfetch && black --version && coverage --version && echo -n 'isort version: ' && isort --version-number",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -81,8 +81,9 @@
 	},
 	"initializeCommand": ["python3", "assets/create-docker-network.py"],
 	"runArgs": [
-		"--network", "autopatch-llm_autopatch-docker-network",
-		"--env-file", ".devcontainer/devcontainer.env"
+		"--network", "autopatch-llm_autopatch-docker-network"
+		// uncomment to add your own env vars
+		// "--env-file", ".devcontainer/devcontainer.env"
 	],
 	"postCreateCommand": "task autopatch:install-devtools",
 	"postStartCommand": "fastfetch && black --version && coverage --version && echo -n 'isort version: ' && isort --version-number",


### PR DESCRIPTION
# remove env file from devontainer initial start up

## Description
This PR fixes when cloning a fresh copy of the repo on main that `devcontainer.env` file is only a `.example` file, make it such that developers have to add it themselves if they want to use it 

## Code Quality Checklist
<!-- Please check off the following items: -->
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, especially in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [N/A] New and existing tests pass locally with my changes.
- [x] I have checked for any linting or style issues.

## Testing
rebuilt the devcontainer off a fresh clone of `main` 


