### PR TITLE
Feature/cpg integrate mqtt

### DIFF
--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -1,7 +1,0 @@
-# Optional.  To use, add:
-#     "--env-file", ".devcontainer/devcontainer.env"
-# to your "runArgs" array in devcontainer.json
-
-FUZZ_SVC_CONFIG=/workspace/AutoPatch-LLM/src/fuzzing-service/dev-config.json
-OPEN_API_KEY='CHANGE_ME'
-LLAMA_API_KEY='CHANGE_ME'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
 			"version": "21"
 		},
 		"ghcr.io/ebaskoro/devcontainer-features/scala:1": {
-			"version": "3.6.3" // current LTS version 3.3.5
+			"version": "3.3.5"
 		},
 		"ghcr.io/devcontainers/features/github-cli:1": {
 			"installDirectlyFromGitHubRelease": true

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ This project is funded by [Google](https://google.com/) and the [National Scienc
 
 [![Google Logo](./docs/images/google-logo.png)](https://google.com) [![NSF CAHSI Logo](./docs/images/NSF-CAHSI-logo.png)](https://cahsi.utep.edu/)  
 
-
-
 High level system design diagram:
 
 ![High Level System Diagram AutoPatch v0.5.1](./docs/Diagrams/autopatch-v.0.5.1.drawio.png)
@@ -35,7 +33,7 @@ High level system design diagram:
 ## Introduction  
 
 
-**AutoPatch**: AutoPatch is an end-2-end GenAI-assisted tool designed to automatically detect and patch bugs in C code by performing vulnerability detection, vulnerability patching, and evaluation of patches for real-world C programs.
+**AutoPatch**: AutoPatch is an end-to-end GenAI-assisted tool designed to automatically detect and patch bugs in C code by performing vulnerability detection, vulnerability patching, and evaluation of patches for real-world C programs.
 
 By combining **Google's Address Sanitizer (ASan)**, **American Fuzzy Lop (AFL++)** and **a competing ensemble of Large Language Models**, AutoPatch targets low level memory safety bugs.  Identifying and resolving memory safety bugs such as Use After Free, Double Free, and Buffer Overlow.
 
@@ -107,15 +105,16 @@ PATCH version increments when a backward compatible bugfix is introduced.
 
 ## Glossary
 
+- **LLM**: large language model, such as GPT, LLAMA, or DeepSeek.
+- **Transformer** is a deep learning architecture that was developed by researchers at Google and is based on the multi-head attention mechanism [1](./docs/References/references.bib).
+  - Text is converted to numerical representations called tokens, and each token is converted into a vector via lookup from a word embedding table.
+  - At each layer, each token is then contextualized within the scope of the context window with other (unmasked) tokens via a parallel multi-head attention mechanism, allowing the signal for key tokens to be amplified and less important tokens to be diminished.
 - **`top_p` (nucleus sampling)** is a decoding parameter that selects from the smallest set of tokens whose cumulative probability exceeds *p*. Tokens are then sampled from this subset.
-- **`temperature`** controls randomness in token sampling: 
-  - Higher values (e.g., 1.0) yield more random output. Example: High temperature (e.g., 0.8): Ideal for creative tasks like brainstorming or storytelling, where diversity and imagination are valued.  Encourages the model to explore less likely words, leading to more creative and diverse outputs, but potentially at the cost of coherence. 
-  - Lower values (e.g., 0.2) make output more deterministic.  Example: Low temperature (e.g., 0.2): Suitable for tasks requiring accuracy and precision, like answering factual questions. 
- Makes the model more likely to select the most probable next word, resulting in predictable and factual outputs.
- 
+- **`temperature`** controls randomness in token sampling:
+  - Higher values (e.g., 1.0) yield more random output. Example: High temperature (e.g., 0.8): Ideal for creative tasks like brainstorming or storytelling, where diversity and imagination are valued.  Encourages the model to explore less likely words, leading to more creative and diverse outputs, but potentially at the cost of coherence.
+  - Lower values (e.g., 0.2) make output more deterministic.  Example: Low temperature (e.g., 0.2): Suitable for tasks requiring accuracy and precision, like answering factual questions. Makes the model more likely to select the most probable next word, resulting in predictable and factual outputs.
+
 - **Memory Safety Bug**: a vulnerability in which memory is accessed or written in a way that violates the logic (intention) or safety of the program, or performs actions outside of the permitted memory of that program. Common examples include buffer overflow, memory leaks, and use after free. If these vulnerabilities can be exposed by specific input by a user, they can be exploited.
 - **Address Sanitizer**: a compilation tool that is capable of improving recognition of memory safety bugs beyond the base compiler. Utilized by a command line argument at compilation time, and can be added as an argument in afl compilation. ASan is the alias commonly used.
 - **Bug Log**: the log made at compile time of a program, contains the output (warnings, errors, or ASan messages depending on the compilation context) of the compilation.
 - **Fuzzer**: a tool that seeks to find all the control flow areas of a program that takes input (via file or stdin) by mutating the input, and logs any crashes or hangs. For more detailed information on fuzzing, refer to docs/QuickStart.md.
-- **LLM**: large language model, such as GPT, LLAMA, or DeepSeek.
-- **Transformer** is a deep learning architecture that was developed by researchers at Google and is based on the multi-head attention mechanism [1](./docs/References/references.bib). Text is converted to numerical representations called tokens, and each token is converted into a vector via lookup from a word embedding table. At each layer, each token is then contextualized within the scope of the context window with other (unmasked) tokens via a parallel multi-head attention mechanism, allowing the signal for key tokens to be amplified and less important tokens to be diminished.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,8 @@ services:
       - autopatch-llm_autopatch-docker-network
     build: ./src/fuzzing-service
     container_name: autopatch-fuzzing-service
-    # user: "${UID:-1000}:${GID:-1000}"
     environment:
       - FUZZ_SVC_CONFIG=/app/config/config.json
-      # - UID=${UID:-1000}
-      # - GID=${GID:-1000}
     volumes:
       - ./src/fuzzing-service/config:/app/config:ro
       - ./src/fuzzing-service/log:/app/log:rw

--- a/src/autopatchdatatypes/autopatchdatatypes/__init__.py
+++ b/src/autopatchdatatypes/autopatchdatatypes/__init__.py
@@ -1,2 +1,2 @@
-from .crash_detail import CrashDetail  # noqa: F401
 from .cpg_scan_result import CpgScanResult  # noqa: F401
+from .crash_detail import CrashDetail  # noqa: F401

--- a/src/autopatchdatatypes/autopatchdatatypes/__init__.py
+++ b/src/autopatchdatatypes/autopatchdatatypes/__init__.py
@@ -1,1 +1,2 @@
 from .crash_detail import CrashDetail  # noqa: F401
+from .cpg_scan_result import CpgScanResult  # noqa: F401

--- a/src/autopatchdatatypes/autopatchdatatypes/cpg_scan_result.py
+++ b/src/autopatchdatatypes/autopatchdatatypes/cpg_scan_result.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class CpgScanResult:
+    executable_name: str
+    vulnerability_severity: float
+    vulnerable_line_number: int
+    vulnerable_function: str
+    vulnerability_description: str

--- a/src/code-property-graph-generator/code_property_graph_generator.py
+++ b/src/code-property-graph-generator/code_property_graph_generator.py
@@ -1,21 +1,19 @@
-import time
 import asyncio
-from dataclasses import dataclass
 import logging
 import os
 import subprocess
 import sys
+import time
+from collections import deque
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Final, List, Deque
-from collections import deque
-
-from cpg_svc_config import CpgSvcConfig
-
 from autopatchpubsub import MessageBrokerClient
-from autopatchshared import init_logging, load_config_as_json, get_current_timestamp
+from autopatchshared import get_current_timestamp, init_logging, load_config_as_json
 from cloudevents.conversion import to_json
 from cloudevents.http import CloudEvent
 from autopatchdatatypes import CpgScanResult
+from cpg_svc_config import CpgSvcConfig
 
 # this is the name of the environment variable that will be used point to the configuration map file to load
 CONST_CPG_SVC_CONFIG: Final[str] = "CPG_SVC_CONFIG"

--- a/src/code-property-graph-generator/code_property_graph_generator.py
+++ b/src/code-property-graph-generator/code_property_graph_generator.py
@@ -25,7 +25,7 @@ config: CpgSvcConfig
 logger = logging.getLogger(__name__)
 
 
-def _remove_joern_scan_temp_file(file_full_path: str) -> None:
+def remove_joern_scan_temp_file(file_full_path: str) -> None:
     """
     Deletes the specified file if it exists.  Does not yet support NT paths.
     """
@@ -53,7 +53,7 @@ def scan_cpg(
     parsed_datasets: List[CpgScanResult] = []
 
     joern_scan_temp_log_file_full_path: Final[str] = "/tmp/joern-scan-log.txt"
-    _remove_joern_scan_temp_file(joern_scan_temp_log_file_full_path)
+    remove_joern_scan_temp_file(joern_scan_temp_log_file_full_path)
 
     timeout_seconds = 120
     command_name_str: Final[str] = cpg_scan_tool_full_path

--- a/src/code-property-graph-generator/code_property_graph_generator.py
+++ b/src/code-property-graph-generator/code_property_graph_generator.py
@@ -291,7 +291,6 @@ async def main():
         scan_results: List[CpgScanResult] = scan_results_queue.popleft()
         await produce_output(scan_results, config.cpg_svc_scan_result_output_topic)
         logger.info(f"Produced {len(scan_results)} scan results.")
-    # logger.info(f"Scan Results as CloudEvents: {scan_results_as_cloud_events_queue}")
 
     CPG_SVC_END_TIMESTAMP: Final[str] = get_current_timestamp()
     time_delta = datetime.fromisoformat(CPG_SVC_END_TIMESTAMP) - datetime.fromisoformat(

--- a/src/code-property-graph-generator/code_property_graph_generator.py
+++ b/src/code-property-graph-generator/code_property_graph_generator.py
@@ -5,14 +5,14 @@ import subprocess
 import sys
 import time
 from collections import deque
-from dataclasses import dataclass
 from datetime import datetime
 from typing import Final, List, Deque
+
+from autopatchdatatypes import CpgScanResult
 from autopatchpubsub import MessageBrokerClient
 from autopatchshared import get_current_timestamp, init_logging, load_config_as_json
 from cloudevents.conversion import to_json
 from cloudevents.http import CloudEvent
-from autopatchdatatypes import CpgScanResult
 from cpg_svc_config import CpgSvcConfig
 
 # this is the name of the environment variable that will be used point to the configuration map file to load
@@ -271,7 +271,6 @@ async def main():
     input_c_programs: Final[List[str]] = os.listdir(config.cpg_svc_input_codebase_path)
 
     scan_results_queue: Deque[List[CpgScanResult]] = deque()
-    scan_results_as_cloud_events_queue: Deque[List[CloudEvent]] = deque()
     len_input_c_programs = len(input_c_programs)
     for i in range(len_input_c_programs):
         fully_qualified_path = os.path.join(

--- a/src/code-property-graph-generator/config/config.json
+++ b/src/code-property-graph-generator/config/config.json
@@ -6,7 +6,6 @@
     "concurrency_threshold": 10,
     "message_broker_host": "mosquitto",
     "message_broker_port": 1883,
-    "message_broker_protocol": "mqtt",
     "cpg_svc_scan_result_output_topic" : "autopatch/cpg-scan-result",
     "cpg_svc_input_codebase_path" : "/app/input_codebase",
     "cpg_svc_output_path" : "/app/data"

--- a/src/code-property-graph-generator/config/dev-config.json
+++ b/src/code-property-graph-generator/config/dev-config.json
@@ -6,7 +6,6 @@
     "concurrency_threshold": 10,
     "message_broker_host": "mosquitto",
     "message_broker_port": 1883,
-    "message_broker_protocol": "mqtt",
     "cpg_svc_scan_result_output_topic" : "autopatch/cpg-scan-result",
     "cpg_svc_input_codebase_path" : "/workspace/AutoPatch-LLM/assets/input_codebase",
     "cpg_svc_output_path" : "/workspace/AutoPatch-LLM/src/code-property-graph-generator/data"

--- a/src/code-property-graph-generator/cpg_svc_config.py
+++ b/src/code-property-graph-generator/cpg_svc_config.py
@@ -9,7 +9,6 @@ class CpgSvcConfig:
     scan_tool_full_path: str
     message_broker_host: str
     message_broker_port: int
-    message_broker_protocol: str
     concurrency_threshold: int
     cpg_svc_scan_result_output_topic: str
     cpg_svc_input_codebase_path: str

--- a/src/code-property-graph-generator/pytest.ini
+++ b/src/code-property-graph-generator/pytest.ini
@@ -1,0 +1,4 @@
+# pytest.ini
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function

--- a/src/code-property-graph-generator/test_code_property_graph_generator.py
+++ b/src/code-property-graph-generator/test_code_property_graph_generator.py
@@ -1,22 +1,18 @@
-import base64
 import logging
-import os
-import subprocess
 from datetime import datetime as real_datetime
 from datetime import timezone
-from types import SimpleNamespace
 from unittest import mock
 
 import code_property_graph_generator as code_property_graph_generator
 import paho.mqtt.client as mqtt_client
 import pytest
-from autopatchdatatypes import CpgScanResult
-from cpg_svc_config import CpgSvcConfig
+# from autopatchdatatypes import CpgScanResult
 
 # Import the function to test from the updated module.
 from code_property_graph_generator import (
     remove_joern_scan_temp_file,
 )
+from cpg_svc_config import CpgSvcConfig
 
 
 def mock_CpgSvcConfig() -> CpgSvcConfig:
@@ -99,6 +95,10 @@ def mock_logger(monkeypatch):
     return logger
 
 
+# --------------
+# tests for remove_joern_scan_temp_file
+# --------------
+
 def test_file_does_not_exist(monkeypatch, mock_logger):
     # Assemble
     monkeypatch.setattr(
@@ -106,7 +106,7 @@ def test_file_does_not_exist(monkeypatch, mock_logger):
     )
 
     # Act
-    code_property_graph_generator.remove_joern_scan_temp_file("fake/path/file.txt")
+    remove_joern_scan_temp_file("fake/path/file.txt")
 
     # Assert
     assert mock_logger.messages == [
@@ -120,7 +120,7 @@ def test_file_deleted_successfully(monkeypatch, mock_logger):
     monkeypatch.setattr(code_property_graph_generator.os, "remove", mock.Mock())
 
     # Act
-    code_property_graph_generator.remove_joern_scan_temp_file("fake/path/file.txt")
+    remove_joern_scan_temp_file("fake/path/file.txt")
 
     # Assert
     assert mock_logger.messages == [
@@ -140,7 +140,7 @@ def test_file_not_found_during_delete(monkeypatch, mock_logger):
     monkeypatch.setattr(code_property_graph_generator.os, "remove", raise_fnf_error)
 
     # Act
-    code_property_graph_generator.remove_joern_scan_temp_file("missing.txt")
+    remove_joern_scan_temp_file("missing.txt")
 
     # Assert
     assert mock_logger.messages == [
@@ -159,7 +159,7 @@ def test_permission_error(monkeypatch, mock_logger):
     monkeypatch.setattr(code_property_graph_generator.os, "remove", raise_perm_error)
 
     # Act
-    code_property_graph_generator.remove_joern_scan_temp_file("secure/file.txt")
+    remove_joern_scan_temp_file("secure/file.txt")
 
     # Assert
     assert mock_logger.messages == [
@@ -178,7 +178,7 @@ def test_generic_exception(monkeypatch, mock_logger):
     monkeypatch.setattr(code_property_graph_generator.os, "remove", raise_generic)
 
     # Act
-    code_property_graph_generator.remove_joern_scan_temp_file("file.txt")
+    remove_joern_scan_temp_file("file.txt")
 
     # Assert
     assert mock_logger.messages == [
@@ -194,7 +194,7 @@ def test_edge_case_empty_path(monkeypatch, mock_logger):
     )
 
     # Act
-    code_property_graph_generator.remove_joern_scan_temp_file("")
+    remove_joern_scan_temp_file("")
 
     # Assert
     assert mock_logger.messages == ["File '' does not exist, no need to delete."]

--- a/src/code-property-graph-generator/test_code_property_graph_generator.py
+++ b/src/code-property-graph-generator/test_code_property_graph_generator.py
@@ -1,0 +1,200 @@
+import base64
+import logging
+import os
+import subprocess
+from datetime import datetime as real_datetime
+from datetime import timezone
+from types import SimpleNamespace
+from unittest import mock
+
+import code_property_graph_generator as code_property_graph_generator
+import paho.mqtt.client as mqtt_client
+import pytest
+from autopatchdatatypes import CpgScanResult
+from cpg_svc_config import CpgSvcConfig
+
+# Import the function to test from the updated module.
+from code_property_graph_generator import (
+    remove_joern_scan_temp_file,
+)
+
+
+def mock_CpgSvcConfig() -> CpgSvcConfig:
+    mock_config = {
+        "version": "0.5.0-alpha",
+        "appname": "autopatch.code-property-graph-generator",
+        "logging_config": "/workspace/AutoPatch-LLM/src/code-property-graph-generator/config/dev-logging-config.json",
+        "scan_tool_full_path": "/opt/joern/joern-cli/joern-scan",
+        "concurrency_threshold": 10,
+        "message_broker_host": "mosquitto",
+        "message_broker_port": 1883,
+        "cpg_svc_scan_result_output_topic": "autopatch/cpg-scan-result",
+        "cpg_svc_input_codebase_path": "/workspace/AutoPatch-LLM/assets/input_codebase",
+        "cpg_svc_output_path": "/workspace/AutoPatch-LLM/src/code-property-graph-generator/data",
+    }
+
+    return CpgSvcConfig(**mock_config)
+
+
+# A dummy logger to capture logger calls.
+class MockLogger:
+    def __init__(self):
+        self.messages = []
+        self.level = logging.DEBUG  # Add the level attribute
+
+    def info(self, msg):
+        self.messages.append(msg)
+
+    def debug(self, msg):
+        self.messages.append(msg)
+
+    def error(self, msg):
+        self.messages.append(msg)
+
+    def log(self, level, msg, *args, **kwargs):
+        self.messages.append(msg)
+
+
+@pytest.fixture(autouse=True)
+def fake_message_broker_client(monkeypatch):
+    class DummyMessageBrokerClient:
+        def __init__(self, *args, **kwargs):
+            self.client = mock.Mock(spec=mqtt_client.Client)
+
+        def publish(self, topic, message):
+            # Optionally, record calls or simply do nothing.
+            # self.client.publish(topic, message)
+            pass
+
+    monkeypatch.setattr(
+        code_property_graph_generator, "MessageBrokerClient", DummyMessageBrokerClient
+    )
+
+
+# A fixed datetime class to always return the same timestamp.
+class FixedDatetime:
+    @classmethod
+    def now(cls) -> str:
+        dt = (
+            real_datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
+        )
+        return dt
+
+    @classmethod
+    def fromisoformat(cls, iso_str):
+        return real_datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+
+
+@pytest.fixture(autouse=True)
+def patch_datetime(monkeypatch):
+    monkeypatch.setattr("code_property_graph_generator.datetime", FixedDatetime)
+
+
+@pytest.fixture(autouse=True)
+def mock_logger(monkeypatch):
+    logger = MockLogger()
+    monkeypatch.setattr("code_property_graph_generator.logger", logger)
+    return logger
+
+
+def test_file_does_not_exist(monkeypatch, mock_logger):
+    # Assemble
+    monkeypatch.setattr(
+        code_property_graph_generator.os.path, "exists", lambda _: False
+    )
+
+    # Act
+    code_property_graph_generator.remove_joern_scan_temp_file("fake/path/file.txt")
+
+    # Assert
+    assert mock_logger.messages == [
+        "File 'fake/path/file.txt' does not exist, no need to delete."
+    ]
+
+
+def test_file_deleted_successfully(monkeypatch, mock_logger):
+    # Assemble
+    monkeypatch.setattr(code_property_graph_generator.os.path, "exists", lambda _: True)
+    monkeypatch.setattr(code_property_graph_generator.os, "remove", mock.Mock())
+
+    # Act
+    code_property_graph_generator.remove_joern_scan_temp_file("fake/path/file.txt")
+
+    # Assert
+    assert mock_logger.messages == [
+        "Attempting to delete fake/path/file.txt",
+        "File 'fake/path/file.txt' has been deleted successfully.",
+    ]
+
+
+def test_file_not_found_during_delete(monkeypatch, mock_logger):
+
+    # Assemble
+    monkeypatch.setattr(code_property_graph_generator.os.path, "exists", lambda _: True)
+
+    def raise_fnf_error(_):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(code_property_graph_generator.os, "remove", raise_fnf_error)
+
+    # Act
+    code_property_graph_generator.remove_joern_scan_temp_file("missing.txt")
+
+    # Assert
+    assert mock_logger.messages == [
+        "Attempting to delete missing.txt",
+        "File 'missing.txt' not found.",
+    ]
+
+
+def test_permission_error(monkeypatch, mock_logger):
+    # Assemble
+    monkeypatch.setattr(code_property_graph_generator.os.path, "exists", lambda _: True)
+
+    def raise_perm_error(_):
+        raise PermissionError()
+
+    monkeypatch.setattr(code_property_graph_generator.os, "remove", raise_perm_error)
+
+    # Act
+    code_property_graph_generator.remove_joern_scan_temp_file("secure/file.txt")
+
+    # Assert
+    assert mock_logger.messages == [
+        "Attempting to delete secure/file.txt",
+        "Permission denied to delete the file 'secure/file.txt'.",
+    ]
+
+
+def test_generic_exception(monkeypatch, mock_logger):
+    # Assemble
+    monkeypatch.setattr(code_property_graph_generator.os.path, "exists", lambda _: True)
+
+    def raise_generic(_):
+        raise RuntimeError("unexpected failure")
+
+    monkeypatch.setattr(code_property_graph_generator.os, "remove", raise_generic)
+
+    # Act
+    code_property_graph_generator.remove_joern_scan_temp_file("file.txt")
+
+    # Assert
+    assert mock_logger.messages == [
+        "Attempting to delete file.txt",
+        "Error occurred while deleting the file: unexpected failure",
+    ]
+
+
+def test_edge_case_empty_path(monkeypatch, mock_logger):
+    # Assemble
+    monkeypatch.setattr(
+        code_property_graph_generator.os.path, "exists", lambda _: False
+    )
+
+    # Act
+    code_property_graph_generator.remove_joern_scan_temp_file("")
+
+    # Assert
+    assert mock_logger.messages == ["File '' does not exist, no need to delete."]

--- a/src/code-property-graph-generator/test_code_property_graph_generator.py
+++ b/src/code-property-graph-generator/test_code_property_graph_generator.py
@@ -6,13 +6,11 @@ from unittest import mock
 import code_property_graph_generator as code_property_graph_generator
 import paho.mqtt.client as mqtt_client
 import pytest
-# from autopatchdatatypes import CpgScanResult
 
-# Import the function to test from the updated module.
-from code_property_graph_generator import (
-    remove_joern_scan_temp_file,
-)
+from code_property_graph_generator import remove_joern_scan_temp_file
 from cpg_svc_config import CpgSvcConfig
+
+# from autopatchdatatypes import CpgScanResult
 
 
 def mock_CpgSvcConfig() -> CpgSvcConfig:
@@ -98,6 +96,7 @@ def mock_logger(monkeypatch):
 # --------------
 # tests for remove_joern_scan_temp_file
 # --------------
+
 
 def test_file_does_not_exist(monkeypatch, mock_logger):
     # Assemble


### PR DESCRIPTION
# Code Property Graph Generator Integration w/ MQTT
CPGScanResults produced by Code Property Graph Generator are now integrated with MQTT

## Description
produce_output() function added to code-property-graph-generator takes a list of CPGScanResult objects and produces cloud events which are passed to MQTT for consumption by other programs. 

## Code Quality Checklist
- [ X] My code follows the project's coding standards.
- [ X] I have performed a self-review of my own code.
- [ ] I have commented my code, especially in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have checked for any linting or style issues.

## Related Issues
TODO remove ` def consume_callback  logger.info() and message_broker_client.consume()` from lines 201 - 204

## Screenshots
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/52835c2b-8bc5-4f1b-9540-ecc942c827b6" />

## Testing


## Additional Notes
Added to_json import statement from cloudevents.conversion 
