### PR TITLE
enable compose stack pull GHCR built images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@
 
 services:
   autopatch-llm-dispatch-service:
+    image: ghcr.io/sysec-uic/autopatch-llm/llm-dispatch-service:0.6.1
     networks:
       - autopatch-llm_autopatch-docker-network
     build: ./src/llm-dispatch-service
@@ -18,6 +19,7 @@ services:
       - ./src/llm-dispatch-service/data:/app/data:ro
     working_dir: /app
   autopatch-code-property-graph-generator:
+    image: ghcr.io/sysec-uic/autopatch-llm/code-property-graph-generator:0.6.1
     networks:
       - autopatch-llm_autopatch-docker-network
     build: ./src/code-property-graph-generator
@@ -31,6 +33,7 @@ services:
       - ./assets/input_codebase:/app/input_codebase:ro
     working_dir: /app
   autopatch-fuzzing-service:
+    image: ghcr.io/sysec-uic/autopatch-llm/fuzzing-service:0.6.1
     networks:
       - autopatch-llm_autopatch-docker-network
     build: ./src/fuzzing-service
@@ -46,6 +49,7 @@ services:
       - ./src/fuzzing-service/seed_input:/app/seed_input:ro
     working_dir: /app
   autopatch-patch-evaluation-service:
+    image: ghcr.io/sysec-uic/autopatch-llm/patch-evaluation-service:0.6.1
     networks:
       - autopatch-llm_autopatch-docker-network
     build: ./src/patch-evaluation-service

--- a/src/code-property-graph-generator/Dockerfile
+++ b/src/code-property-graph-generator/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 0: Base
 FROM ubuntu:noble AS base
 
+LABEL org.opencontainers.image.description="Code Property Graph Service"
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/src/fuzzing-service/Dockerfile
+++ b/src/fuzzing-service/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:noble AS base
 
+LABEL org.opencontainers.image.description="Fuzzing Service"
+
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1
 

--- a/src/llm-dispatch-service/Dockerfile
+++ b/src/llm-dispatch-service/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:noble AS base
 
+LABEL org.opencontainers.image.description="LLM Dispatch Service"
+
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
# add tagged version image to compose stack pull

## Description
feature(deployment stack): add tagged version image to compose stack so devs and deploys don't need to build the images locally

## Code Quality Checklist
<!-- Please check off the following items: -->
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, especially in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] I have checked for any linting or style issues.

## Related Issues
<!-- Add any related work items -->

## Screenshots
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/fec5d8a6-a805-45b4-998d-09e73a74c5c4" />

## Testing
<!-- Describe the steps you took to test your changes.
     Include details such as the environment used, test cases executed, and how reviewers can reproduce your results. -->

