### PR TITLE
 Added CpgScanResult message consumption too llm dispatch service.

### DIFF
--- a/src/code-property-graph-generator/code_property_graph_generator.py
+++ b/src/code-property-graph-generator/code_property_graph_generator.py
@@ -4,9 +4,8 @@ import os
 import subprocess
 import sys
 import time
-from collections import deque
 from datetime import datetime
-from typing import Deque, Final, List
+from typing import Final, List
 
 from autopatchdatatypes import CpgScanResult
 from autopatchpubsub import MessageBrokerClient

--- a/src/llm-dispatch-service/config/config.json
+++ b/src/llm-dispatch-service/config/config.json
@@ -1,4 +1,5 @@
 {
+    "cpg_scan_result_input_topic" : "autopatch/cpg-scan-result",
     "devonlyinputfilepath": "/app/data/dummy_c_file.c",
     "appName": "autopatch.llm-dispatch-service",
     "appVersion": "0.7.0-alpha",

--- a/src/llm-dispatch-service/config/dev-config.json
+++ b/src/llm-dispatch-service/config/dev-config.json
@@ -1,4 +1,5 @@
 {
+    "cpg_scan_result_input_topic" : "autopatch/cpg-scan-result",
     "devonlyinputfilepath": "/workspace/AutoPatch-LLM/src/llm-dispatch-service/data/dummy_c_file.c",
     "appName": "autopatch.llm-dispatch-service",
     "appVersion": "0.7.0-alpha",

--- a/src/llm-dispatch-service/llm_dispatch_svc.py
+++ b/src/llm-dispatch-service/llm_dispatch_svc.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Dict, Final, List
 
-from autopatchdatatypes import PatchResponse, TransformerMetadata, CpgScanResult
+from autopatchdatatypes import CpgScanResult, PatchResponse, TransformerMetadata
 from autopatchpubsub import MessageBrokerClient
 from autopatchshared import get_current_timestamp, init_logging, load_config_as_json
 from cloudevents.conversion import to_json

--- a/src/llm-dispatch-service/llm_dispatch_svc.py
+++ b/src/llm-dispatch-service/llm_dispatch_svc.py
@@ -59,7 +59,7 @@ async def map_cloud_event_as_cpg_scan_result(
 
 
 async def process_cpg_scan_result(cpg_scan_result: CpgScanResult) -> None:
-    logger.info(f"Processing crash {cpg_scan_result}")
+    logger.info(f"Processing cpg scan result: {cpg_scan_result}")
     # TODO evaluate if we can remove this check
     # if the crash executable is not in our executables base, then skip it
     if cpg_scan_result.executable_name not in executable_name_to_cpg_scan_result_map:

--- a/src/llm-dispatch-service/llm_dispatch_svc.py
+++ b/src/llm-dispatch-service/llm_dispatch_svc.py
@@ -647,7 +647,7 @@ async def main():
     config = load_config(config_full_path)
     logger = init_logging(config.logging_config, config.appName)
 
-    LLM_DISPATCH_START_TIMESTAMP: Final[str] = get_current_timestamp()
+    # LLM_DISPATCH_START_TIMESTAMP: Final[str] = get_current_timestamp()
 
     models = [
         "openai/gpt-4o-mini:free",

--- a/src/llm-dispatch-service/llm_dispatch_svc.py
+++ b/src/llm-dispatch-service/llm_dispatch_svc.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import json
 import logging
 import os
 import re
@@ -8,13 +9,18 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Dict, Final, List
 
-from autopatchdatatypes import PatchResponse, TransformerMetadata
+from autopatchdatatypes import PatchResponse, TransformerMetadata, CpgScanResult
 from autopatchpubsub import MessageBrokerClient
 from autopatchshared import get_current_timestamp, init_logging, load_config_as_json
 from cloudevents.conversion import to_json
 from cloudevents.http import CloudEvent
 from llm_dispatch_svc_config import LLMDispatchSvcConfig
 from openai import OpenAI
+
+# Global variables for the async queue and event loop.
+async_cpg_scan_results_queue = asyncio.Queue()
+event_loop: asyncio.AbstractEventLoop  # This will be set in main().
+
 
 # from autopatchdatatypes import PatchRequest
 
@@ -24,6 +30,69 @@ config: LLMDispatchSvcConfig
 
 # before configuration is loaded, use the default logger
 logger = logging.getLogger(__name__)
+
+executable_name_to_cpg_scan_result_map: Dict[str, CpgScanResult] = {}
+
+
+async def map_cloud_event_as_cpg_scan_result(
+    cpg_scan_result_cloud_event_str: str,
+) -> CpgScanResult:
+    """
+    Maps a CloudEvent JSON string to a CpgScanResult object.
+
+    Parameters:
+        cloud_event (str): The CloudEvent JSON string.
+
+    Returns:
+        CpgScanResult: The mapped cpg scan result.
+    """
+    cloud_event: Dict = json.loads(cpg_scan_result_cloud_event_str)
+
+    data = cloud_event.get("data", {})
+
+    return CpgScanResult(
+        executable_name=data.get("executable_name", ""),
+        vulnerability_severity=data.get("vulnerability_severity", None),
+        vulnerable_line_number=data.get("vulnerable_line_number", None),
+        vulnerable_function=data.get("vulnerable_function", ""),
+        vulnerability_description=data.get("vulnerability_description", ""),
+    )
+
+
+async def process_cpg_scan_result(cpg_scan_result: CpgScanResult) -> None:
+    logger.info(f"Processing crash {cpg_scan_result}")
+    # TODO evaluate if we can remove this check
+    # if the crash executable is not in our executables base, then skip it
+    if cpg_scan_result.executable_name not in executable_name_to_cpg_scan_result_map:
+        logger.info(
+            f"{cpg_scan_result.executable_name} not in set of compiled executables to process.. adding to map"
+        )
+        executable_name_to_cpg_scan_result_map[cpg_scan_result.executable_name] = (
+            cpg_scan_result
+        )
+        logger.info(
+            f"Current executable_name_cpg_scan_result_map: {executable_name_to_cpg_scan_result_map.items()}"
+        )
+
+
+async def process_item(item):
+    """Asynchronously process an item."""
+    cpg_scan_result = await map_cloud_event_as_cpg_scan_result(item)
+    await process_cpg_scan_result(cpg_scan_result)
+
+
+async def cpg_scan_result_consumer():
+    """Continuously consume items from the async queue."""
+    """
+        this consumer coroutine waits for items from the asyncio.Queue
+        and processes each with process_item(). This runs continuously in the event loop.
+    """
+    while True:
+        item = await async_cpg_scan_results_queue.get()
+        try:
+            await process_item(item)
+        finally:
+            async_cpg_scan_results_queue.task_done()
 
 
 def load_config(json_config_full_path: str) -> LLMDispatchSvcConfig:
@@ -225,9 +294,26 @@ async def map_patchresponses_as_cloudevents(
     return results
 
 
+def on_consume_cpg_scan_result(cloud_event_str: str) -> None:
+    """
+    This is synchronous function that’s called from non‑async code.
+    It uses the globally stored event_loop to schedule a call to
+    async_queue.put_nowait in a thread‑safe manner.
+    """
+    logger.info(f"in on_consume_cpg_scan_result received {cloud_event_str}")
+    # Schedule adding the event to the async queue.
+    # Use call_soon_threadsafe so that this function can be safely called
+    # from threads outside the event loop.
+    global event_loop
+    event_loop.call_soon_threadsafe(
+        async_cpg_scan_results_queue.put_nowait, cloud_event_str
+    )
+
+
 async def produce_output(
     patch_response_output_topic: str,
     patch_responses: List[PatchResponse],
+    message_broker_client: MessageBrokerClient,
     concurrency_threshold: int = 10,
 ) -> None:
 
@@ -241,9 +327,6 @@ async def produce_output(
 
     patch_response_cloud_events: List[CloudEvent] = (
         await map_patchresponses_as_cloudevents(patch_responses)
-    )
-    message_broker_client: Final[MessageBrokerClient] = MessageBrokerClient(
-        config.message_broker_host, config.message_broker_port, logger
     )
 
     logger.info(f"Producing {len(patch_response_cloud_events)} CloudEvents.")
@@ -534,8 +617,25 @@ async def create_patch_response(
     )
 
 
+def init_message_broker(
+    message_broker_host: str, message_broker_port: int, logger: logging.Logger
+) -> MessageBrokerClient:
+    """
+    Initialize a MessageBrokerClient instance with the configured host, port, and logger settings.
+    Returns:
+        MessageBrokerClient: The configured MessageBrokerClient ready for use.
+    """
+    message_broker_client: Final[MessageBrokerClient] = MessageBrokerClient(
+        message_broker_host,
+        message_broker_port,
+        logger,
+    )
+    return message_broker_client
+
+
 async def main():
     global config, logger
+    global event_loop
 
     config_full_path = os.environ.get(CONST_LLM_DISPATCH_CONFIG)
 
@@ -574,19 +674,40 @@ async def main():
 
     dummy_filename = "dummy_c_file.c"
 
+    event_loop = asyncio.get_running_loop()
+
+    # Start the consumer coroutine as a background task.
+    asyncio.create_task(cpg_scan_result_consumer())
+
+    message_broker_client: Final[MessageBrokerClient] = init_message_broker(
+        config.message_broker_host,
+        config.message_broker_port,
+        logger,
+    )
+
+    # subscribe to topic
+    message_broker_client.consume(
+        config.cpg_scan_result_input_topic, on_consume_cpg_scan_result
+    )
+
     responses = await client.generate(prompt)
     patch_responses: List[PatchResponse] = await create_patch_responses(
         responses, [dummy_filename] * len(responses)
     )
-    await produce_output(config.message_broker_topics["response"], patch_responses)
+    await produce_output(
+        config.message_broker_topics["response"], patch_responses, message_broker_client
+    )
 
-    LLM_DISPATCH_END_TIMESTAMP: Final[str] = get_current_timestamp()
-    time_delta = datetime.fromisoformat(
-        LLM_DISPATCH_END_TIMESTAMP
-    ) - datetime.fromisoformat(LLM_DISPATCH_START_TIMESTAMP)
-    logger.info(f"Total Processing Time Elapsed: {time_delta}")
-    logger.info("Processing complete, exiting.")
-    exit(0)
+    # LLM_DISPATCH_END_TIMESTAMP: Final[str] = get_current_timestamp()
+    # time_delta = datetime.fromisoformat(
+    #     LLM_DISPATCH_END_TIMESTAMP
+    # ) - datetime.fromisoformat(LLM_DISPATCH_START_TIMESTAMP)
+    # logger.info(f"Total Processing Time Elapsed: {time_delta}")
+    # logger.info("Processing complete, exiting.")
+
+    # TODO finish making event driven
+    # Keep the program running indefinitely, waiting for more events.
+    await asyncio.Future()  # This future will never complete.
 
 
 if __name__ == "__main__":

--- a/src/llm-dispatch-service/llm_dispatch_svc.py
+++ b/src/llm-dispatch-service/llm_dispatch_svc.py
@@ -6,7 +6,6 @@ import os
 import re
 import sys
 from abc import ABC, abstractmethod
-from datetime import datetime
 from typing import Dict, Final, List
 
 from autopatchdatatypes import CpgScanResult, PatchResponse, TransformerMetadata

--- a/src/llm-dispatch-service/llm_dispatch_svc_config.py
+++ b/src/llm-dispatch-service/llm_dispatch_svc_config.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 
 @dataclass
 class LLMDispatchSvcConfig:
+    cpg_scan_result_input_topic: str
     devonlyinputfilepath: str
     appName: str
     appVersion: str

--- a/src/llm-dispatch-service/test_llm_dispatch_service.py
+++ b/src/llm-dispatch-service/test_llm_dispatch_service.py
@@ -26,6 +26,7 @@ llm_dispatch_svc_module_name_str: Final[str] = "llm_dispatch_svc"
 
 def mock_LLMDispatchSvcConfig() -> LLMDispatchSvcConfig:
     mock_config = {
+        "cpg_scan_result_input_topic": "autopatch/cpg-scan-result",
         "devonlyinputfilepath": "/workspace/AutoPatch-LLM/src/llm-dispatch/data/dummy_c_file.c",
         "appName": "autopatch.llm-dispatch",
         "appVersion": "0.5.0-alpha",


### PR DESCRIPTION
# Added CpgScanResult message consumption too llm dispatch service.


## Description
feature(llm-dispatch-service-consumes-cpg-scan-results): llm dispatch service now consumes cpg scan results and maps them to their executable names holding them in memory. cpg generator now produces per program under consideration.

code-property-graph-generator now produces output after each scan instead of holding until the end.

## Code Quality Checklist
- [X] My code follows the project's coding standards.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, especially in hard-to-understand areas.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing tests pass locally with my changes.
- [X] I have checked for any linting or style issues.

## Related Issues
GitHub Issue #94 

## Screenshots
![image](https://github.com/user-attachments/assets/41096162-d239-4f6b-b70e-a6c2b1a3405c)


## Testing
Fixed tests.
