### PR TITLE
tests: add coverage gutters for test coverage viewing locally

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -69,7 +69,8 @@
 				"bierner.markdown-mermaid",
 				"bpruitt-goddard.mermaid-markdown-syntax-highlighting",
 				"MS-vsliveshare.vsliveshare",
-				"GitHub.vscode-github-actions"
+				"GitHub.vscode-github-actions",
+				"ryanluker.vscode-coverage-gutters"
 			],
 			"settings": {
 				"git.enableCommitSigning": true,


### PR DESCRIPTION
# add coverage gutters for test coverage viewing locally


## Description
This PR adds a devtool to the devcontainer that allows developers to view test coverage reports intergrated into vscode

Run tests with coverage from the test explorer (or on the command line) to generate coverage reports and view the context, this aligns with the same tooling used in the CI system

use the UI (pictured below)
or use the task cli hook with 
`task test-with-coverage`

or directly with
`pytest --junitxml=pytest.xml --cov --cov-report=xml:./coverage.xml --cov-report=term`

Covered and uncovered lines then appear with:
<img width="717" alt="image" src="https://github.com/user-attachments/assets/29ff1cfc-ebb9-4cd7-b473-63ae56df90c2" />



## Code Quality Checklist
<!-- Please check off the following items: -->
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, especially in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] I have checked for any linting or style issues.

## Related Issues
<!-- Add any related work items -->

## Screenshots
<img width="225" alt="image" src="https://github.com/user-attachments/assets/ca8f3e57-a926-43db-8f50-2ad36361ab54" />

![image](https://github.com/user-attachments/assets/e8eb8750-d829-4b1a-8087-bc401d205121)

